### PR TITLE
Development

### DIFF
--- a/Source/setup.py
+++ b/Source/setup.py
@@ -7,6 +7,7 @@ with open('agstools/_version.py') as fin: exec(fin)
 
 packages = [
 	"agstools",
+    "agstools.arcpy",
     "agstools.arcpyext",
     "agstools.agsadmin",
 ]


### PR DESCRIPTION
Fixing missing package in setup.py. What do you think about using:
    packages=find_packages(),

You could even use:
    package_dir={'':'Source'},
    packages=find_packages('Source'),

if you want to move setup.py back to the root dir...

Not sure where the GPServer commit came from - too tired to examine tonight, will figure out tomorrow...
